### PR TITLE
Import actions dynamically

### DIFF
--- a/example/example.ini
+++ b/example/example.ini
@@ -12,6 +12,7 @@
 endpoint = "http://{}".format(os.getenv("BIND"))
 pool_size = 10
 concurrency = 10
+actions_prefix = "smapy.actions"
 
 [mongodb]
 database = "smapy"

--- a/example/example.py
+++ b/example/example.py
@@ -3,6 +3,7 @@
 import logging
 import os
 
+from smapy import API, resources
 from smapy.logging import SessionFilter
 from smapy.utils import setenv, read_conf
 
@@ -57,12 +58,7 @@ def get_app(api_conf):
 
     logging.getLogger().info("Initializing the API")
 
-    # Import actions and resources here to make sure that the
-    # environment is already configured
-    from smapy import API, actions, resources
     api = API(conf)
-
-    api.load_actions(actions.modules)
 
     # Misc
     api.add_resource("/multi_process", resources.misc.MultiProcess)

--- a/smapy/resource.py
+++ b/smapy/resource.py
@@ -156,13 +156,7 @@ class BaseResource(Runnable):
     # ##########################
 
     def _get_runnable(self, runnable):
-        runnable_class = self.api.runnables.get(runnable)
-        if not runnable_class:
-            raise falcon.HTTPInternalServerError(
-                'Invalid Runnable',
-                'Runnable {} not found in registry'.format(runnable)
-            )
-
+        runnable_class = self.api.get_runnable(runnable)
         return runnable_class(self.request)
 
     @staticmethod

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -75,7 +77,7 @@ class TestBaseAction(TestCase):
             'Traceback (most recent call last):\n',
             '  File "{}smapy/action.py", line 63, in run_local\n'
             '    self.process(message)\n'.format(project_dir),
-            '  File "{}tests/test_action.py", line 53, in process\n'
+            '  File "{}tests/test_action.py", line 55, in process\n'
             '    raise Exception("An Exception")\n'.format(project_dir),
             'Exception: An Exception\n'
         ]
@@ -123,7 +125,7 @@ class TestBaseAction(TestCase):
             'Traceback (most recent call last):\n',
             '  File "{}smapy/action.py", line 63, in run_local\n'
             '    self.process(message)\n'.format(project_dir),
-            '  File "{}tests/test_action.py", line 101, in process\n'
+            '  File "{}tests/test_action.py", line 103, in process\n'
             '    raise SystemExit()\n'.format(project_dir),
             'SystemExit\n'
         ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import traceback
 from importlib import reload
 from unittest import TestCase
@@ -165,7 +167,6 @@ class TestAPI(TestCase):
         api_.load_actions(modules)
 
         # Asserts
-        action.init.assert_called_once_with(api_)
         api_._add_runnable.assert_called_once_with(action)
 
     # #####################################################
@@ -176,21 +177,14 @@ class TestAPI(TestCase):
 
         # Set up
         resource = Mock()
-
-        # Override __init__
-        api.API.__init__ = lambda x: None
-        api_ = api.API()
-
-        # Mock _add_runnable and add_route
-        api_._add_runnable = Mock()
-        api_.add_route = Mock()
+        api_ = Mock()
+        api_.add_resource = api.API.add_resource.__get__(api_, api.API)
 
         # Actual call
         api_.add_resource('a_route', resource, keyword='argument')
 
         # Asserts
-        resource.init.assert_called_once_with(api_, 'a_route', keyword='argument')
-        api_._add_runnable.assert_called_once_with(resource)
+        api_._add_runnable.assert_called_once_with(resource, route='a_route', keyword='argument')
         api_.add_route.assert_called_once_with('a_route', resource)
 
     # #############################

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import datetime
 from unittest import TestCase
 from unittest.mock import MagicMock, patch

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
+
 from unittest import TestCase
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import Mock, call, patch
 
 import falcon
 from bson import ObjectId
@@ -10,7 +12,7 @@ from smapy.resource import BaseResource
 class TestBaseResource(TestCase):
 
     def setUp(self):
-        self.api = MagicMock(endpoint='http://host:port')
+        self.api = Mock(endpoint='http://host:port')
 
     # #######################
     # init(cls, api, rouce) #
@@ -25,7 +27,7 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 pass
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         route = '/a_route'
         TestResource.init(api, route)
@@ -49,12 +51,12 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 return {'a': 'response'}
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         TestResource.init(api, 'a_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         test_resource = TestResource(a_request)
 
         response = test_resource.run_local({'a': 'message'})
@@ -70,12 +72,12 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 return {'a': 'response'}
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         TestResource.init(api, 'a_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         test_resource = TestResource(a_request)
 
         response = test_resource.run_local({})
@@ -91,12 +93,12 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 message['a'] = 'response'
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         TestResource.init(api, 'a_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         test_resource = TestResource(a_request)
 
         response = test_resource.run_local({})
@@ -115,8 +117,8 @@ class TestBaseResource(TestCase):
     #            return message
 
     #    session = ObjectId('57b599f8ab1785652bb879a7')
-    #    request = MagicMock(params={'some': 'params'}, context={'session': session})
-    #    response = MagicMock()
+    #    request = Mock(params={'some': 'params'}, context={'session': session})
+    #    response = Mock()
     #    TestResource.on_get(request, response)
 
     #    self.assertEqual({'some': 'params'}, response.body)
@@ -134,8 +136,8 @@ class TestBaseResource(TestCase):
     #            return message
 
     #    session = ObjectId('57b599f8ab1785652bb879a7')
-    #    request = MagicMock(body={'some': 'params'}, context={'session': session})
-    #    response = MagicMock()
+    #    request = Mock(body={'some': 'params'}, context={'session': session})
+    #    response = Mock()
     #    TestResource.on_post(request, response)
 
     #    self.assertEqual({'some': 'params'}, response.body)
@@ -146,58 +148,12 @@ class TestBaseResource(TestCase):
     def test__get_runnable_success(self):
         """If runnable exists, return a new instance."""
 
-        class OneResource(BaseResource):
+        resource = Mock()
+        resource._get_runnable = BaseResource._get_runnable.__get__(resource, BaseResource)
 
-            name = 'one_resource'
-
-            def process(self, message):
-                pass
-
-        class AnOtherResource(BaseResource):
-
-            name = 'an_other_resource'
-
-            def process(self, message):
-                pass
-
-        runnables = {
-            'one_resource': OneResource,
-            'an_other_resource': AnOtherResource
-        }
-        api = MagicMock(runnables=runnables)
-        OneResource.init(api, '/one_resource')
-        AnOtherResource.init(api, '/an_other_resource')
-
-        session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
-        one_resource = OneResource(a_request)
-
-        other_runnable = one_resource._get_runnable('an_other_resource')
-
-        self.assertIsInstance(other_runnable, AnOtherResource)
-
-    def test__get_runnable_invalid(self):
-        """If runnable does not exist, raise an exception."""
-
-        class OneResource(BaseResource):
-
-            name = 'one_resource'
-
-            def process(self, message):
-                pass
-
-        runnables = {
-            'one_resource': OneResource,
-        }
-        api = MagicMock(runnables=runnables)
-        OneResource.init(api, '/one_resource')
-
-        session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
-        one_resource = OneResource(a_request)
-
-        with self.assertRaises(falcon.HTTPInternalServerError):
-            one_resource._get_runnable('an_other_resource')
+        resource._get_runnable('a_runnable')
+        resource.api.get_runnable.assert_called_once_with('a_runnable')
+        resource.api.get_runnable.return_value.assert_called_once_with(resource.request)
 
     # ####################
     # _is_many(messages) #
@@ -242,20 +198,20 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 pass
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         OneResource.init(api, 'one_route')
         OtherResource.init(api, 'other_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         one_resource = OneResource(a_request)
         other_resource = OtherResource(a_request)
 
-        one_resource._get_runnable = MagicMock(return_value=other_resource)
-        other_resource.run = MagicMock()
+        one_resource._get_runnable = Mock(return_value=other_resource)
+        other_resource.run = Mock()
 
-        pool_mock = MagicMock()
+        pool_mock = Mock()
         pool_mock.spawn.side_effect = ['g1', 'g2', 'g3']
         pool_class_mock.return_value = pool_mock
 
@@ -295,18 +251,18 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 pass
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         OneResource.init(api, 'one_route')
         OtherResource.init(api, 'other_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         one_resource = OneResource(a_request)
         other_resource = OtherResource(a_request)
 
-        one_resource._get_runnable = MagicMock(return_value=other_resource)
-        other_resource.run = MagicMock()
+        one_resource._get_runnable = Mock(return_value=other_resource)
+        other_resource.run = Mock()
 
         # Actual call
         one_resource._run_one('other_resource', {}, 1, False)
@@ -329,18 +285,18 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 pass
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         OneResource.init(api, 'one_route')
         OtherResource.init(api, 'other_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         one_resource = OneResource(a_request)
         other_resource = OtherResource(a_request)
 
-        one_resource._get_runnable = MagicMock(return_value=other_resource)
-        other_resource.run = MagicMock()
+        one_resource._get_runnable = Mock(return_value=other_resource)
+        other_resource.run = Mock()
 
         # Actual call
         one_resource._run_one('other_resource', [{}], 1, False)
@@ -361,12 +317,12 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 pass
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         OneResource.init(api, 'one_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         one_resource = OneResource(a_request)
 
         runnables = ['runnable_1', 'runnable_2', 'runnable_3']
@@ -399,15 +355,15 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 pass
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         OneResource.init(api, 'one_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         one_resource = OneResource(a_request)
 
-        pool_mock = MagicMock()
+        pool_mock = Mock()
         pool_mock.spawn.side_effect = ['g1', 'g2', 'g3']
         pool_class_mock.return_value = pool_mock
 
@@ -440,16 +396,16 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 pass
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         OneResource.init(api, 'one_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         one_resource = OneResource(a_request)
 
-        one_resource._run_many = MagicMock()
-        one_resource._run_one = MagicMock()
+        one_resource._run_many = Mock()
+        one_resource._run_one = Mock()
 
         # Actual call
         runnable = ['runnable_1', 'runnable_2', 'runnable_3']
@@ -469,16 +425,16 @@ class TestBaseResource(TestCase):
             def process(self, message):
                 pass
 
-        api = MagicMock()
+        api = Mock()
         api.endpoint = 'http://an_endpoint'
         OneResource.init(api, 'one_route')
 
         session = ObjectId('57b599f8ab1785652bb879a7')
-        a_request = MagicMock(context={'session': session})
+        a_request = Mock(context={'session': session})
         one_resource = OneResource(a_request)
 
-        one_resource._run_many = MagicMock()
-        one_resource._run_one = MagicMock()
+        one_resource._run_many = Mock()
+        one_resource._run_one = Mock()
 
         # Actual call
         runnable = 'a_runnable'

--- a/tests/test_runnable.py
+++ b/tests/test_runnable.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import copy
 import datetime
 import json

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import datetime
 from unittest import TestCase
 from unittest.mock import Mock, patch


### PR DESCRIPTION
Resolve #2 

Import actions dynamically from the name.
A prefix can be set in the config, so the name does not need to be the entire import path.